### PR TITLE
Updates!

### DIFF
--- a/bin/markdown-invoice
+++ b/bin/markdown-invoice
@@ -16,7 +16,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Process\Process;
-use dflydev\markdown\MarkdownExtraParser;
+use Michelf\MarkdownExtra;
 
 $console = new Application;
 $console
@@ -56,7 +56,7 @@ $console
         'layout'  => $input->getOption('layout'),
         'src'     => $input->getArgument('src')
       ];
-      
+
       $filesystem  = new Filesystem;
       $invoice_dir = __DIR__."/../invoices/{$args['src']}/";
 
@@ -91,10 +91,10 @@ $console
         $output->writeln("<error>Layout file does not seem to exit for \"{$args['layout']}\".</error>");
         exit;
       }
-      
+
       $layout_html = str_replace(
         '{{ html }}',
-        (new MarkdownExtraParser)->transformMarkdown(file_get_contents($invoice_path)),
+        MarkdownExtra::defaultTransform(file_get_contents($invoice_path)),
         file_get_contents($args['layout'])
       );
       file_put_contents($save_path, $layout_html);
@@ -102,7 +102,7 @@ $console
       $output->writeln('');
       $output->writeln("<info>Invoice compiled to HTML.</info>");
       $output->writeln("<info>HTML saved to: {$save_path}</info>");
-      
+
       if ($args['format'] ==  'pdf') {
         # Save HTML to PDF if PDF format was chosen
         $pdf_save_path = substr_replace($save_path, 'pdf', strlen($save_path)-4, 4);

--- a/composer.json
+++ b/composer.json
@@ -11,9 +11,9 @@
         }
     ],
     "require": {
-        "dflydev/markdown": "dev-master",
+        "michelf/php-markdown": "1.9.0",
         "symfony/console": "2.7.4",
-   	    "symfony/process": "2.7.4",
+        "symfony/process": "2.7.4",
         "symfony/filesystem": "2.7.4",
         "symfony/finder": "2.7.4"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -1,37 +1,35 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "hash": "e5af542899d4212790119326fb845c15",
+    "content-hash": "e4be6818ea317147941e4d60e9160c3a",
     "packages": [
         {
-            "name": "dflydev/markdown",
-            "version": "dev-master",
+            "name": "michelf/php-markdown",
+            "version": "1.9.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/dflydev/dflydev-markdown.git",
-                "reference": "dee1f7a6b60776a94c10efa8340ccd486ec834b7"
+                "url": "https://github.com/michelf/php-markdown.git",
+                "reference": "c83178d49e372ca967d1a8c77ae4e051b3a3c75c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/dflydev/dflydev-markdown/zipball/dee1f7a6b60776a94c10efa8340ccd486ec834b7",
-                "reference": "dee1f7a6b60776a94c10efa8340ccd486ec834b7",
+                "url": "https://api.github.com/repos/michelf/php-markdown/zipball/c83178d49e372ca967d1a8c77ae4e051b3a3c75c",
+                "reference": "c83178d49e372ca967d1a8c77ae4e051b3a3c75c",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3"
+                "php": ">=5.3.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": ">=4.3 <5.8"
             },
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.0-dev"
-                }
-            },
             "autoload": {
-                "psr-0": {
-                    "dflydev\\markdown": "src"
+                "psr-4": {
+                    "Michelf\\": "Michelf/"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -40,43 +38,38 @@
             ],
             "authors": [
                 {
-                    "name": "Dragonfly Development Inc.",
-                    "email": "info@dflydev.com",
-                    "homepage": "http://dflydev.com"
-                },
-                {
-                    "name": "Beau Simensen",
-                    "email": "beau@dflydev.com",
-                    "homepage": "http://beausimensen.com"
-                },
-                {
                     "name": "Michel Fortin",
-                    "homepage": "http://michelf.com"
+                    "email": "michel.fortin@michelf.ca",
+                    "homepage": "https://michelf.ca/",
+                    "role": "Developer"
                 },
                 {
                     "name": "John Gruber",
-                    "homepage": "http://daringfireball.net"
+                    "homepage": "https://daringfireball.net/"
                 }
             ],
-            "description": "PHP Markdown & Extra - DEPRECATED",
-            "homepage": "http://github.com/dflydev/dflydev-markdown",
+            "description": "PHP Markdown",
+            "homepage": "https://michelf.ca/projects/php-markdown/",
             "keywords": [
                 "markdown"
             ],
-            "abandoned": "michelf/php-markdown",
-            "time": "2014-01-06 23:32:02"
+            "support": {
+                "issues": "https://github.com/michelf/php-markdown/issues",
+                "source": "https://github.com/michelf/php-markdown/tree/1.9.0"
+            },
+            "time": "2019-12-02T02:32:27+00:00"
         },
         {
             "name": "symfony/console",
             "version": "v2.7.4",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/Console.git",
+                "url": "https://github.com/symfony/console.git",
                 "reference": "9ff9032151186bd66ecee727d728f1319f52d1d8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/Console/zipball/9ff9032151186bd66ecee727d728f1319f52d1d8",
+                "url": "https://api.github.com/repos/symfony/console/zipball/9ff9032151186bd66ecee727d728f1319f52d1d8",
                 "reference": "9ff9032151186bd66ecee727d728f1319f52d1d8",
                 "shasum": ""
             },
@@ -121,19 +114,22 @@
             ],
             "description": "Symfony Console Component",
             "homepage": "https://symfony.com",
-            "time": "2015-09-03 11:40:38"
+            "support": {
+                "source": "https://github.com/symfony/console/tree/v2.7.4"
+            },
+            "time": "2015-09-03T11:40:38+00:00"
         },
         {
             "name": "symfony/filesystem",
             "version": "v2.7.4",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/Filesystem.git",
+                "url": "https://github.com/symfony/filesystem.git",
                 "reference": "f079e9933799929584200b9a926f72f29e291654"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/Filesystem/zipball/f079e9933799929584200b9a926f72f29e291654",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/f079e9933799929584200b9a926f72f29e291654",
                 "reference": "f079e9933799929584200b9a926f72f29e291654",
                 "shasum": ""
             },
@@ -170,7 +166,10 @@
             ],
             "description": "Symfony Filesystem Component",
             "homepage": "https://symfony.com",
-            "time": "2015-08-27 07:03:44"
+            "support": {
+                "source": "https://github.com/symfony/filesystem/tree/v2.7.4"
+            },
+            "time": "2015-08-27T07:03:44+00:00"
         },
         {
             "name": "symfony/finder",
@@ -219,7 +218,10 @@
             ],
             "description": "Symfony Finder Component",
             "homepage": "https://symfony.com",
-            "time": "2015-08-26 17:56:37"
+            "support": {
+                "source": "https://github.com/symfony/Finder/tree/2.7"
+            },
+            "time": "2015-08-26T17:56:37+00:00"
         },
         {
             "name": "symfony/process",
@@ -268,17 +270,19 @@
             ],
             "description": "Symfony Process Component",
             "homepage": "https://symfony.com",
-            "time": "2015-08-27 06:45:45"
+            "support": {
+                "source": "https://github.com/symfony/Process/tree/2.7"
+            },
+            "time": "2015-08-27T06:45:45+00:00"
         }
     ],
     "packages-dev": [],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": {
-        "dflydev/markdown": 20
-    },
+    "stability-flags": [],
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": [],
-    "platform-dev": []
+    "platform-dev": [],
+    "plugin-api-version": "2.0.0"
 }


### PR DESCRIPTION
Hi!

First of all, thanks for publishing this tool. No matter how small, it is still useful, at least to me. I don't usually do PHP and, frankly, shy away from it. But this package is well-done, has crisp clear instructions, the code & packaging is understandable to an outsider (I've never run `composer` before) — and it *worked* right away, after very minor tinkering.

BTW, I used PHP **8.0.2** from my distro repositories. At first, it failed in the deprecated dependency [`dflydev/markdown`][fork] like so:

```
Generating for invoice "2013-01-15-sample"...
PHP Fatal error:  Array and string offset access syntax with curly braces is no longer supported in /home/ulidtko/src/markdown-invoice/vendor/dflydev/markdown/src/dflydev/markdown/MarkdownExtraParser.php on line 347
```

Composer did a very nice suggestion:
> Package dflydev/markdown is abandoned, you should avoid using it. Use michelf/php-markdown instead.

I did exactly that. Didn't touch the Symfony dependencies.

So there you have it: sincere words of appreciation from a "php hater" :scream: plus a patch. Take care & best wishes!

[fork]: https://packagist.org/packages/dflydev/markdown